### PR TITLE
Replace deprecated lazy_static with once_cell and minor documentation graph suggestion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rand_chacha = "0.3.1"
 sha2 = "0.10.8"
 hex = "0.4.3"
 covenants-gadgets = { git = "https://github.com/Bitcoin-Wildlife-Sanctuary/covenants" }
-lazy_static = "1.4.0"
+once_cell = "1.19.0"
 log = "0.4.21"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Some examples of covenants
 
 ### Transaction flow
 
+```
 // structure:
 //
 // input:
@@ -19,3 +20,16 @@ Some examples of covenants
 // output:
 //   this program (copy)
 //   new state: OP_RETURN (4 bytes for the counter value) (4 bytes for randomness)
+```
+
+```mermaid
+graph TD
+    A[Input]
+    B[This Program] --> A[This Program]
+    C[Another Paying Input] --> A[Input]
+    D[Output]
+    D --> E[Copy of This Program]
+    D --> F[New State: OP_RETURN]
+    F --> G[Counter Value 4 bytes]
+    F --> H[Randomness 4 bytes]
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-use lazy_static::lazy_static;
-lazy_static! {
-    pub static ref SECP256K1_GENERATOR: Vec<u8> =
-        hex::decode("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798").unwrap();
-}
+use hex;
+use once_cell::sync::Lazy;
+
+pub static SECP256K1_GENERATOR: Lazy<Vec<u8>> = Lazy::new(|| {
+    hex::decode("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798").unwrap()
+});
 
 pub mod counter;


### PR DESCRIPTION
Since `lazy_static` has been [deprecated officially for a year](https://github.com/rust-lang-nursery/lazy-static.rs/issues/214), suggesting to use once_cell from the beginning. 
I also tried to take the diagram in readme and generate a mermaid diagram to hopefully make it clearer.